### PR TITLE
chore: drop support for Python 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["3.6", "3.7", "3.8", "3.9"]
+        pythonversion: ["3.7", "3.8", "3.9"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v1.1.0 (2021-09-20)
+
+* Drops support for Python 3.6
+* Removes unused `mock` library
+
 ## v1.0.0 (2021-05-13)
 
 * Switched from shelling out to Pip to using the internal Pip API natively via Python (closes #4 and closes #2), this change makes the previous ~1 minute operation now take ~1 second!

--- a/pip_tree/tree.py
+++ b/pip_tree/tree.py
@@ -8,12 +8,10 @@ import time
 import pkg_resources
 
 
-class PipTreeCli():
+class PipTreeCli:
     def __init__(self):
         parser = argparse.ArgumentParser(
-            description=(
-                'Get the dependency tree of your Python virtual environment via Pip.'
-            )
+            description='Get the dependency tree of your Python virtual environment via Pip.'
         )
         parser.add_argument(
             '-p',
@@ -24,19 +22,17 @@ class PipTreeCli():
         parser.parse_args(namespace=self)
 
     def generate_console_output(self):
-        """Take the output of the dependency tree and print to console.
-        """
+        """Take the output of the dependency tree and print to console."""
         print('Generating Pip Tree report...')
         final_output, package_count = PipTree.generate_pip_tree(self.path)
         print(json.dumps(final_output, indent=4))
         print(f'Pip Tree report complete! {package_count} dependencies found for "{self.path}".')
 
 
-class PipTree():
+class PipTree:
     @staticmethod
     def generate_pip_tree(path):
-        """Generate the Pip Tree of the virtual environment specified.
-        """
+        """Generate the Pip Tree of the virtual environment specified."""
         pip_tree_results = []
         required_by_dict = {}
         package_count = 0
@@ -64,19 +60,19 @@ class PipTree():
         Must be a path like: /project/venv/lib/python3.9/site-packages
         """
         packages = pkg_resources.find_distributions(path)
+
         return packages
 
     @staticmethod
     def get_package_object(package):
-        """Returns a package object from Pip.
-        """
+        """Returns a package object from Pip."""
         package_object = pkg_resources.get_distribution(package)
+
         return package_object
 
     @staticmethod
     def get_package_details(package):
-        """Build a dictionary of details for a package from Pip.
-        """
+        """Build a dictionary of details for a package from Pip."""
         package_update_at = time.ctime(os.path.getctime(package.location))
         requires_list = [sorted(str(requirement) for requirement in package.requires())]
         package_details = {
@@ -85,6 +81,7 @@ class PipTree():
             'updated': datetime.datetime.strptime(package_update_at, "%a %b %d %H:%M:%S %Y").strftime("%Y-%m-%d"),
             'requires': [item for sublist in requires_list for item in sublist],
         }
+
         return package_details
 
     @staticmethod
@@ -100,11 +97,8 @@ class PipTree():
             if required_by_dict.get(required_by_package_name):
                 required_by_dict[required_by_package_name].append(package_details['name'])
             else:
-                required_by_dict.update(
-                    {
-                        required_by_package_name: [package_details['name']]
-                    }
-                )
+                required_by_dict.update({required_by_package_name: [package_details['name']]})
+
         return required_by_dict
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,13 @@ with open('README.md', 'r') as fh:
 DEV_REQUIREMENTS = [
     'coveralls == 3.*',
     'flake8',
-    'mock == 4.*',
     'pytest == 6.*',
     'pytest-cov == 2.*',
 ]
 
 setuptools.setup(
     name='pip-tree',
-    version='1.0.0',
+    version='1.1.0',
     description='Get the dependency tree of your Python virtual environment via Pip.',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -27,12 +26,12 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     extras_require={
-        'dev': DEV_REQUIREMENTS
+        'dev': DEV_REQUIREMENTS,
     },
     entry_points={
         'console_scripts': [
-            'pip-tree=pip_tree.tree:main'
-        ]
+            'pip-tree=pip_tree.tree:main',
+        ],
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )

--- a/test/unit/test_tree.py
+++ b/test/unit/test_tree.py
@@ -3,20 +3,18 @@ import sys
 from pip_tree import PipTree
 
 
-def get_python_version():
-    return sys.version.split(' ')[0][:3]
-
-
 def test_get_package_details():
     """The poor man's approach to unit testing this library is to feed
     its own virtual environment details to itself and assert they match.
 
     Asserting the entire collection is difficult due to odd environment
     dependencies (such as pip itself being a different version in build systems),
-    simply assert that certain attributes exist for a package such as `pytest`.
+    so we simply assert that certain attributes exist for a package such as `pytest`.
     """
-    pip_path = f'./venv/lib/python{get_python_version()}/site-packages'
+    python_version = sys.version.split(' ')[0][:3]
+    pip_path = f'./venv/lib/python{python_version}/site-packages'
     package_details, package_count = PipTree.generate_pip_tree(pip_path)
+
     assert any(item['name'] == 'pytest-cov' for item in package_details)
     assert any('toml' in item['requires'] for item in package_details)
     assert any('pytest' in item['required_by'] for item in package_details)


### PR DESCRIPTION
* Drops support for Python 3.6
* Removes unused `mock` library