### PR TITLE
introduce Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 120

--- a/justfile
+++ b/justfile
@@ -4,10 +4,6 @@ VIRTUAL_BIN := VIRTUAL_ENV / "bin"
 PROJECT_NAME := "pip_tree"
 TEST_DIR := "test"
 
-# Scans the project for security vulnerabilities
-bandit:
-    {{VIRTUAL_BIN}}/bandit -r {{PROJECT_NAME}}/
-
 # Builds the project in preparation for release
 build:
     {{VIRTUAL_BIN}}/python -m build
@@ -29,28 +25,20 @@ clean:
     rm -rf {{VIRTUAL_ENV}} dist *.egg-info .coverage htmlcov .*cache
     find . -name '*.pyc' -delete
 
-# Run flake8 checks against the project
-flake8:
-    {{VIRTUAL_BIN}}/flake8 {{PROJECT_NAME}}/ {{TEST_DIR}}/
+# Run Ruff checks against the project
+ruff:
+    {{VIRTUAL_BIN}}/ruff {{PROJECT_NAME}}/ {{TEST_DIR}}/
 
 # Lints the project
-lint: black-check isort-check flake8 mypy bandit
+lint: black-check ruff mypy
 
 # Runs all formatting tools against the project
-lint-fix: black isort
+lint-fix: black
 
 # Install the project locally
 install:
     {{PYTHON_BINARY}} -m venv {{VIRTUAL_ENV}}
     {{VIRTUAL_BIN}}/pip install -e ."[dev]"
-
-# Sorts imports throughout the project
-isort:
-    {{VIRTUAL_BIN}}/isort {{PROJECT_NAME}}/ {{TEST_DIR}}/
-
-# Checks that imports throughout the project are sorted correctly
-isort-check:
-    {{VIRTUAL_BIN}}/isort {{PROJECT_NAME}}/ {{TEST_DIR}}/ --check-only
 
 # Run mypy type checking on the project
 mypy:

--- a/pip_tree/__init__.py
+++ b/pip_tree/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from pip_tree.tree import (
     SITE_PACKAGES_PATH,
     generate_pip_tree,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,33 @@ preview = true
 line-length = 120
 skip-string-normalization = true
 
-[tool.isort]
-profile = "black"
-line_length = 120
-indent = 4
-force_grid_wrap = 2
-multi_line_output = 3
-sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER"
-lines_after_imports = 2
-include_trailing_comma = true
-use_parentheses = true
+
+[tool.ruff]
+ line-length = 120
+ select = [
+    "E", "W",  # see: https://pypi.org/project/pycodestyle
+    "F",  # see: https://pypi.org/project/pyflakes
+    "I",  #see: https://pypi.org/project/isort/
+    "S",  # see: https://pypi.org/project/flake8-bandit
+ #   "D",  # see: https://pypi.org/project/pydocstyle
+ ]
+# todo
+# extend-select = [
+#    "A",  # see: https://pypi.org/project/flake8-builtins
+#    "B",  # see: https://pypi.org/project/flake8-bugbear
+#    "C4",  # see: https://pypi.org/project/flake8-comprehensions
+#    "PT",  # see: https://pypi.org/project/flake8-pytest-style
+#    "RET",  # see: https://pypi.org/project/flake8-return
+#    "SIM",  # see: https://pypi.org/project/flake8-simplify
+# ]
+ ignore = [
+     "E731",
+ ]
+ ignore-init-module-imports = true
+
+[tool.ruff.pydocstyle]
+# Use Google-style docstrings.
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ DEV_REQUIREMENTS = [
     'bandit == 1.7.*',
     'black == 23.*',
     'build == 0.10.*',
-    'flake8 == 6.*',
+    'ruff == 0.1.*',
     'isort == 5.*',
     'mypy == 1.5.*',
     'pytest == 7.*',


### PR DESCRIPTION
[Ruff](https://github.com/astral-sh/ruff) is a very fast and all-in-one replacement for several fragmented tools used for lining. I have been using it for a while all good experience, so I may suggest using it also here, which would effectively replace `flake8`, `isort`, and `bandit`

Remaining todo:
- [ ] double check that just is correct, if #11 merged this will be easier
- [ ] maybe `ruff` run will be needed to be lint